### PR TITLE
Fix formatter corrupting {button} macros in HTML blocks

### DIFF
--- a/src/plugins/format/placeholders.ts
+++ b/src/plugins/format/placeholders.ts
@@ -1,11 +1,14 @@
 /**
  * Regex matching Spindle tokens in HTML:
  * - {/macroName} closing tags
- * - {macroName ...} opening tags (with optional CSS prefix)
+ * - {macroName ...} opening tags (with optional CSS prefix, balanced nested braces)
  * - {$variable}, {_variable}, {@variable} (with optional dot paths)
  * - [[links]]
  */
-const SPINDLE_TOKEN_REGEX = /(?:\{\/[A-Za-z][\w-]*\s*\}|\{(?:[#.][a-zA-Z][\w-]*\s*)*[A-Za-z][\w-]*(?:\s+(?:[^}]|\}(?=[^}]))*?)?\}|\{[$_@][a-zA-Z][\w.]*\}|\[\[(?:[^\]]*)\]\])/g;
+const SPINDLE_TOKEN_REGEX = /(?:\{\/[A-Za-z][\w-]*\s*\}|\{(?:[#.][a-zA-Z][\w-]*\s*)*[A-Za-z][\w-]*(?:\s+(?:[^{}]|\{[^{}]*\})*)?\}|\{[$_@][a-zA-Z][\w.]*\}|\[\[(?:[^\]]*)\]\])/g;
+
+/** Detect HTML tags in text (opening or self-closing or closing). */
+const HTML_TAG_REGEX = /<\/?[a-zA-Z][\w-]*[\s>/]/;
 
 /**
  * Check if a position in the string is inside an HTML attribute value.
@@ -34,19 +37,53 @@ export interface PlaceholderResult {
 /**
  * Replace Spindle tokens with placeholders.
  * Uses <!--SP:N--> in HTML content and __SPN__ in attribute values.
+ *
+ * Lines that contain Spindle tokens but no HTML tags are replaced as a
+ * single whole-line placeholder so Prettier cannot split them.
  */
 export function replaceSpindleTokens(html: string): PlaceholderResult {
   const tokens: string[] = [];
-  const text = html.replace(SPINDLE_TOKEN_REGEX, (match, ...args) => {
-    const offset = args[args.length - 2] as number;
-    const idx = tokens.length;
-    tokens.push(match);
-    if (isInsideAttribute(html, offset)) {
-      return `__SP${idx}__`;
+  const lines = html.split('\n');
+  const resultLines: string[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Check if line has any Spindle tokens
+    SPINDLE_TOKEN_REGEX.lastIndex = 0;
+    if (!SPINDLE_TOKEN_REGEX.test(trimmed)) {
+      resultLines.push(line);
+      continue;
     }
-    return `<!--SP:${idx}-->`;
-  });
-  return { text, tokens };
+
+    // Check if line has HTML tags after removing Spindle tokens
+    SPINDLE_TOKEN_REGEX.lastIndex = 0;
+    const withoutSpindle = trimmed.replace(SPINDLE_TOKEN_REGEX, '');
+    const hasHtml = HTML_TAG_REGEX.test(withoutSpindle);
+
+    if (!hasHtml) {
+      // Line has Spindle tokens but no HTML — replace entire line with one placeholder
+      const idx = tokens.length;
+      tokens.push(trimmed);
+      const indent = line.match(/^(\s*)/)?.[1] ?? '';
+      resultLines.push(`${indent}<!--SP:${idx}-->`);
+    } else {
+      // Line has both HTML and Spindle — replace individual tokens
+      SPINDLE_TOKEN_REGEX.lastIndex = 0;
+      const replaced = line.replace(SPINDLE_TOKEN_REGEX, (match, ...args) => {
+        const matchOffset = args[args.length - 2] as number;
+        const idx = tokens.length;
+        tokens.push(match);
+        if (isInsideAttribute(line, matchOffset)) {
+          return `__SP${idx}__`;
+        }
+        return `<!--SP:${idx}-->`;
+      });
+      resultLines.push(replaced);
+    }
+  }
+
+  return { text: resultLines.join('\n'), tokens };
 }
 
 /**

--- a/test/unit/format.test.ts
+++ b/test/unit/format.test.ts
@@ -277,6 +277,84 @@ describe('formatDocument', () => {
     expect(result).toContain('[[Home]]');
   });
 
+  // -- HTML blocks with Spindle macros (regression) ----------------------
+
+  it('preserves {button} inside HTML blocks', async () => {
+    const input = [
+      ':: Actions [nobr]',
+      '<div class="menu">',
+      '{for @action of $actions}',
+      '<button class="btn" data-action="do" data-id="{@action.id}">{@action.name}</button>',
+      '{/for}',
+      '</div>',
+      '',
+    ].join('\n');
+    const result = await formatDocument(input);
+    // The <button> tag must remain intact — not split across lines or corrupted
+    expect(result).toContain('<button');
+    expect(result).toContain('</button>');
+    // The macro tokens inside attributes must survive
+    expect(result).toContain('{@action.id}');
+    expect(result).toContain('{@action.name}');
+  });
+
+  it('preserves {button} with macro arguments inside {widget}', async () => {
+    const input = [
+      ':: Widgets [widget]',
+      '{widget "OpenPad" @view @label}',
+      '<div class="choices-section">',
+      '{button "{@label}"}{set $view = @view}{do} Story.goto("blank"); {/do}{/button}',
+      '</div>',
+      '{/widget}',
+      '',
+    ].join('\n');
+    const result = await formatDocument(input);
+    // The single-line {button} must not be split across multiple lines
+    const buttonLine = result.split('\n').find(l => l.includes('{button'));
+    expect(buttonLine).toBeDefined();
+    expect(buttonLine).toContain('{/button}');
+  });
+
+  it('is idempotent with <button> inside {for} in HTML blocks', async () => {
+    const input = [
+      ':: Panel [nobr]',
+      '<div class="panel">',
+      '{for @item of $items}',
+      '<button class="item-btn" data-id="{@item.id}">{@item.name}</button>',
+      '{/for}',
+      '</div>',
+      '',
+    ].join('\n');
+    const first = await formatDocument(input);
+    const second = await formatDocument(first);
+    expect(second).toBe(first);
+  });
+
+  it('is idempotent with complex ALMA-style panel', async () => {
+    const input = [
+      ':: ALMAPanel [nobr]',
+      '<div class="alma-panel">',
+      '<div class="header">Day {$game.day}</div>',
+      '{if $npc_plans.length > 0}',
+      '<div class="crew">',
+      '{for @plan of $npc_plans}',
+      '<div class="row"><span>{@plan.name}</span></div>',
+      '{/for}',
+      '</div>',
+      '{/if}',
+      '<div class="actions">',
+      '{for @action of $actions}',
+      '<button class="action-btn {if @action.cost > $ap.current}disabled{/if}" data-action="game-action" data-action-id="{@action.id}"><span>{@action.name}</span><span>{@action.cost} AP</span></button>',
+      '{/for}',
+      '</div>',
+      '</div>',
+      '',
+    ].join('\n');
+    const first = await formatDocument(input);
+    const second = await formatDocument(first);
+    expect(second).toBe(first);
+  });
+
   // -- Idempotency -------------------------------------------------------
 
   it('is idempotent — double formatting produces same result', async () => {


### PR DESCRIPTION
## Summary
- Fix placeholder regex to handle balanced nested braces in macro arguments (e.g. `{button "{@label}"}` was split at the inner `}`)
- Replace Spindle-only lines inside HTML blocks with a single whole-line placeholder before Prettier, preventing adjacent macros from being split across lines

## Test plan
- [x] Failing test from issue passes: `{button "{@label}"}{set ...}{do}...{/do}{/button}` stays on one line
- [x] All 402 tests pass (38 test files, zero regressions)

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)