### PR TITLE
Fix formatter idempotency with multi-attribute HTML tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Language Server Protocol server for Spindle story format",
   "type": "module",
   "bin": {
-    "spindle-lsp": "./dist/bin.js"
+    "spindle-lsp": "dist/bin.js"
   },
   "scripts": {
     "build": "node esbuild.config.ts",

--- a/src/plugins/format/segment.ts
+++ b/src/plugins/format/segment.ts
@@ -131,7 +131,7 @@ export function segmentRegions(body: string): Region[] {
       i++;
       while (i < lines.length && depth > 0) {
         htmlLines.push(lines[i]);
-        const opens = (lines[i].match(new RegExp(`<${tagName}[\\s>]`, 'gi')) ?? []).length;
+        const opens = (lines[i].match(new RegExp(`<${tagName}(?:[\\s>]|$)`, 'gi')) ?? []).length;
         const closes = (lines[i].match(new RegExp(`</${tagName}\\s*>`, 'gi')) ?? []).length;
         depth += opens - closes;
         i++;

--- a/test/unit/format.test.ts
+++ b/test/unit/format.test.ts
@@ -355,6 +355,24 @@ describe('formatDocument', () => {
     expect(second).toBe(first);
   });
 
+  it('is idempotent with multi-attribute div and {include} macros', async () => {
+    const input = [
+      ':: StoryInterface',
+      '<div id="interface">',
+      '<div id="top-bar">',
+      '{include "TopBar"}',
+      '</div>',
+      '<div id="main" class="main-content-area" data-section="primary" data-scrollable="true">',
+      '{include "PCStatus"}',
+      '</div>',
+      '</div>',
+      '',
+    ].join('\n');
+    const first = await formatDocument(input);
+    const second = await formatDocument(first);
+    expect(second).toBe(first);
+  });
+
   // -- Idempotency -------------------------------------------------------
 
   it('is idempotent — double formatting produces same result', async () => {


### PR DESCRIPTION
## Summary
- Fix opens regex in segment detector to match `<div` at end-of-line (adds `|$` alternative), so Prettier's multi-line attribute splits are correctly counted as nested opens
- Add idempotency test with multi-attribute `<div>` and `{include}` macros

## Test plan
- [x] New test reproduces the exact failure: second format pass adds extra `</div>`
- [x] All 403 tests pass (zero regressions)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)