### PR TITLE
fix: preserve SVG blocks from prettier reformatting

### DIFF
--- a/src/plugins/format.ts
+++ b/src/plugins/format.ts
@@ -3,7 +3,7 @@ import type { SpindlePlugin, PluginContext } from '../core/plugin/plugin-api.js'
 import supplements from '../macro-supplements.json' with { type: 'json' };
 import { splitPassages, classifyPassage, segmentRegions } from './format/segment.js';
 import { formatJS, formatCSS, formatHTML as formatHTMLPrettier } from './format/prettier-bridge.js';
-import { replaceSpindleTokens, restoreSpindleTokens } from './format/placeholders.js';
+import { replaceSpindleTokens, restoreSpindleTokens, replaceSvgBlocks, restoreSvgBlocks } from './format/placeholders.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -145,12 +145,20 @@ export async function formatDocument(text: string, options?: FormatOptions): Pro
         continue;
       }
 
+      if (region.type === 'svg') {
+        // SVG block — leave untouched (Prettier would break rendering)
+        resultLines.push(...region.lines);
+        continue;
+      }
+
       if (region.type === 'html') {
         // HTML block — placeholder substitution + Prettier
         const htmlText = region.lines.join('\n');
-        const { text: placeholdered, tokens } = replaceSpindleTokens(htmlText);
+        const { text: svgPlaceholdered, tokens: svgTokens } = replaceSvgBlocks(htmlText);
+        const { text: placeholdered, tokens } = replaceSpindleTokens(svgPlaceholdered);
         const formatted = await formatHTMLPrettier(placeholdered);
-        const restored = restoreSpindleTokens(formatted.trim(), tokens);
+        const restoredSpindle = restoreSpindleTokens(formatted.trim(), tokens);
+        const restored = restoreSvgBlocks(restoredSpindle, svgTokens);
         for (const fLine of restored.split('\n')) {
           resultLines.push(fLine);
         }

--- a/src/plugins/format/placeholders.ts
+++ b/src/plugins/format/placeholders.ts
@@ -35,6 +35,32 @@ export interface PlaceholderResult {
 }
 
 /**
+ * Replace `<svg>…</svg>` blocks with HTML comment placeholders so Prettier
+ * does not reformat them (CommonMark does not recognise multi-line SVG tags
+ * as HTML blocks, so reformatted attributes break rendering).
+ */
+export function replaceSvgBlocks(html: string): PlaceholderResult {
+  const tokens: string[] = [];
+  const result = html.replace(/<svg[\s>][\s\S]*?<\/svg>/gi, (match) => {
+    const idx = tokens.length;
+    tokens.push(match);
+    return `<!--SVG:${idx}-->`;
+  });
+  return { text: result, tokens };
+}
+
+/**
+ * Restore SVG blocks from placeholders.
+ */
+export function restoreSvgBlocks(text: string, tokens: string[]): string {
+  let result = text;
+  for (let i = 0; i < tokens.length; i++) {
+    result = result.replace(`<!--SVG:${i}-->`, tokens[i]);
+  }
+  return result;
+}
+
+/**
  * Replace Spindle tokens with placeholders.
  * Uses <!--SP:N--> in HTML content and __SPN__ in attribute values.
  *

--- a/src/plugins/format/segment.ts
+++ b/src/plugins/format/segment.ts
@@ -6,7 +6,7 @@ export interface Passage {
 }
 
 export interface Region {
-  type: 'spindle' | 'html' | 'script';
+  type: 'spindle' | 'html' | 'script' | 'svg';
   lines: string[];
 }
 
@@ -102,6 +102,24 @@ export function segmentRegions(body: string): Region[] {
         i++;
       }
       regions.push({ type: 'script', lines: scriptLines });
+      continue;
+    }
+
+    // Detect <svg> blocks — treat as opaque to prevent Prettier from
+    // breaking multi-line attributes (CommonMark does not list svg as a
+    // type-6 HTML block tag, so reformatted multi-line tags break rendering).
+    if (/^<svg(\s|>)/i.test(trimmed)) {
+      const svgLines: string[] = [line];
+      i++;
+      while (i < lines.length && !/<\/svg>/i.test(lines[i])) {
+        svgLines.push(lines[i]);
+        i++;
+      }
+      if (i < lines.length) {
+        svgLines.push(lines[i]); // closing </svg>
+        i++;
+      }
+      regions.push({ type: 'svg', lines: svgLines });
       continue;
     }
 

--- a/test/unit/format.test.ts
+++ b/test/unit/format.test.ts
@@ -373,6 +373,51 @@ describe('formatDocument', () => {
     expect(second).toBe(first);
   });
 
+  // -- SVG preservation (issue #5) ----------------------------------------
+
+  it('does not reformat SVG tags to multi-line', async () => {
+    const input = [
+      ':: Test',
+      '<div class="wrapper"><svg class="my-svg" width="100" height="100" viewBox="0 0 100 100">',
+      '<circle cx="50" cy="50" r="40"></circle>',
+      '</svg></div>',
+      '',
+    ].join('\n');
+    const result = await formatDocument(input);
+    // SVG attributes must stay on one line — not broken across lines by Prettier
+    expect(result).toContain('viewBox="0 0 100 100"');
+    expect(result).not.toContain('<svg\n');
+  });
+
+  it('is idempotent with SVG blocks', async () => {
+    const input = [
+      ':: Test',
+      '<svg class="my-svg" width="100" height="100" viewBox="0 0 100 100">',
+      '<circle cx="50" cy="50" r="40"></circle>',
+      '</svg>',
+      '',
+    ].join('\n');
+    const first = await formatDocument(input);
+    const second = await formatDocument(first);
+    expect(second).toBe(first);
+  });
+
+  it('preserves SVG inside a wrapper div without reformatting', async () => {
+    const input = [
+      ':: Icons',
+      '<div class="icon-container">',
+      '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor">',
+      '<path d="M12 2L2 7l10 5 10-5-10-5z"></path>',
+      '</svg>',
+      '</div>',
+      '',
+    ].join('\n');
+    const result = await formatDocument(input);
+    // The SVG opening tag must not be split across lines
+    const svgLine = result.split('\n').find(l => l.includes('<svg'));
+    expect(svgLine).toContain('viewBox="0 0 24 24"');
+  });
+
   // -- Idempotency -------------------------------------------------------
 
   it('is idempotent — double formatting produces same result', async () => {


### PR DESCRIPTION
## Summary

- Treat `<svg>…</svg>` as opaque regions so the formatter does not reformat them via prettier
- Standalone SVG blocks detected in `segmentRegions()` (new `'svg'` region type, like `<script>`)
- SVG nested inside HTML blocks swapped with placeholders before prettier, restored after

Closes #5

## Test plan

- [x] New test: standalone SVG attributes not broken to multi-line
- [x] New test: SVG idempotency
- [x] New test: SVG nested inside wrapper div preserved
- [x] All 406 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)